### PR TITLE
Fix usage of bold text helper in find-route command

### DIFF
--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -52,11 +52,11 @@ class PryRails::FindRoute < Pry::ClassCommand
     if all_routes.any?
       grouped_routes = all_routes.group_by { |route| route.defaults[:controller] }
       result = grouped_routes.each_with_object("") do |(controller, routes), res|
-        res << "Routes for " + text.bold(controller.to_s.camelize + "Controller") + "\n"
+        res << "Routes for " + bold(controller.to_s.camelize + "Controller") + "\n"
         res << "--\n"
         routes.each do |route|
           spec = route.path.is_a?(String) ? route.path : route.path.spec
-          res << "#{route.defaults[:action]} #{text.bold(verb_for(route))} #{spec}  #{route_helper(route.name)}" + "\n"
+          res << "#{route.defaults[:action]} #{bold(verb_for(route))} #{spec}  #{route_helper(route.name)}" + "\n"
         end
         res << "\n"
       end


### PR DESCRIPTION
`Pry::Command#text` was deprecated in pry 0.12.0 and removed in pry 0.13.0 which is the minimal supported version by pry-rails according to gemspec

> Deprecated Pry::Command#text. Please use #black, #white, etc. directly instead (as you would with helper functions from BaseHelpers and CommandHelpers) ([#1701](https://github.com/pry/pry/pull/1701))

It was broken before (NoMethodError) and works now with my manual test but I can't get the whole test-shebang to run