### PR TITLE
Adds support for Rails version >= 7.2

### DIFF
--- a/lib/pry-rails/railtie.rb
+++ b/lib/pry-rails/railtie.rb
@@ -18,11 +18,32 @@ module PryRails
         Rails.application.config.console = Pry
       end
 
-      if (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR >= 2) ||
-          Rails::VERSION::MAJOR >= 4
+      major = Rails::VERSION::MAJOR
+      minor = Rails::VERSION::MINOR
+
+      if (major == 3 && minor >= 2) || (major >= 4 && (major < 7 || (major == 7 && minor < 2)))
         require "rails/console/app"
         require "rails/console/helpers"
         TOPLEVEL_BINDING.eval('self').extend ::Rails::ConsoleMethods
+      end
+
+      if major > 7 || (major == 7 && minor >= 2)
+        require "rails/commands/console/irb_console"
+
+        Module.new do
+          def reload!
+            puts "Reloading..."
+            Rails.application.reloader.reload!
+          end
+
+          ::IRB::HelperMethod.helper_methods.each do |name, helper_method_class|
+            define_method name do |*args, **opts, &block|
+              helper_method_class.instance.execute(*args, **opts, &block)
+            end
+          end
+
+          TOPLEVEL_BINDING.eval("self").extend self
+        end
       end
     end
   end


### PR DESCRIPTION
After upgrading [Rails console using IRB's latest official extension APIs](https://github.com/rails/rails/pull/51705) pry-rails fails to open the console.

This change takes Rails' console helper methods defined in `IRB::HelperMethod.helper_methods` and adds them to the main object.

----

I know this repository is "not actively maintained", but if there's a chance to merge this PR, I'll add tests as well. Let me know.